### PR TITLE
Fix streaming endpoint to use SSE

### DIFF
--- a/src/main/java/dev/danvega/streaming/ChatController.java
+++ b/src/main/java/dev/danvega/streaming/ChatController.java
@@ -1,6 +1,7 @@
 package dev.danvega.streaming;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 
@@ -22,7 +23,7 @@ public class ChatController {
                 .content();
     }
 
-    @GetMapping("/stream")
+    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> chatWithStream(@RequestParam String message) {
         return chatClient.prompt()
                 .user(message)


### PR DESCRIPTION
## Summary
- enable server-sent events on the streaming endpoint

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_684ab14e9ef0832fa77933fc586a5bbb